### PR TITLE
Port configurable (80 par défaut).

### DIFF
--- a/custom_components/apiFreebox/const.py
+++ b/custom_components/apiFreebox/const.py
@@ -2,4 +2,4 @@
 
 
 ISSUE_URL="https://github.com/saniho/apiFreebox/issues"
-__VERSION__ = "1.0.1.0" # attention updater aussi manifest.json
+__VERSION__ = "1.0.1.1" # attention updater aussi manifest.json

--- a/custom_components/apiFreebox/manifest.json
+++ b/custom_components/apiFreebox/manifest.json
@@ -3,7 +3,7 @@
     "name": "apiFreebox sensor",
     "documentation": "https://github.com/saniho/apiFreeBox/",
     "config_flow": false,
-    "version": "1.0.1.0",
+    "version": "1.0.1.1",
     "requirements": [
     ],
     "dependencies": [],


### PR DESCRIPTION
Ma Freebox et Home Assistant étant sur deux réseaux différents, j'accède au serveur via l'URL de type `*.fbxos.fr`.
Comme j'ai réservé les ports 80 et 443 pour Home Assistant, j'ai besoin de passer par le [port d'accès distant](http://mafreebox.freebox.fr/#Fbx.os.app.settings.ConnectionConfig).